### PR TITLE
add 'dez' to month object to fix work in december

### DIFF
--- a/Apple-Order-Status/Apple-Store-Order-Status.js
+++ b/Apple-Order-Status/Apple-Store-Order-Status.js
@@ -241,7 +241,8 @@ const parseShortDate = (stringDate, orderDate) => {
     'Oct': 9,
     'Okt': 9,
     'Nov': 10,
-    'Dec': 11
+    'Dec': 11,
+    'Dez': 11
   }
   let m
   m = stringDate.match(/([\d]{1,2}) ([\w]{3})/)


### PR DESCRIPTION
I noticed that the apple order status won't work in december and tracked it down to the missing `dez`. 